### PR TITLE
Do not modify VENDOR_MAC_OUI

### DIFF
--- a/sniffles/ruletrafficgenerator.py
+++ b/sniffles/ruletrafficgenerator.py
@@ -1647,7 +1647,7 @@ class EthernetFrame:
         return self.s_mac
 
     def get_random_octets(self, prefix):
-        random_octets = prefix
+        random_octets = list(prefix)
         start = len(random_octets)
         for o in range(start, 6):
             random_octets.append(random.randint(0, 255))

--- a/sniffles/test/test_examples.py
+++ b/sniffles/test/test_examples.py
@@ -1,6 +1,5 @@
 from unittest import *
 from sniffles.ruletrafficgenerator import *
-from sniffles.vendor_mac_list import vendor_oui
 
 
 class TestExamples(TestCase):

--- a/sniffles/test/test_rule_traffic_generator.py
+++ b/sniffles/test/test_rule_traffic_generator.py
@@ -1,21 +1,14 @@
 from unittest import *
 from sniffles.ruletrafficgenerator import *
-from sniffles.vendor_mac_list import vendor_oui
+from sniffles.vendor_mac_list import VENDOR_MAC_OUI
 
 
 class TestRuleTrafficGenerator(TestCase):
     def test_build_random_ethernet_header(self):
         random.seed()
-        myouilist = []
-        lines = vendor_oui.splitlines()
-        for line in lines:
-            line = line.lower().strip()
-            myouilist.append(line)
         myehdr = EthernetFrame('10.0.0.1', '10.1.1.1', ETHERNET_HDR_GEN_RANDOM)
-        self.assertIn(''.join(['%02x' % i for i in myehdr.get_d_mac()[0:3]]),
-                      myouilist)
-        self.assertIn(''.join(['%02x' % i for i in myehdr.get_s_mac()[0:3]]),
-                      myouilist)
+        self.assertIn(myehdr.get_d_mac()[0:3], VENDOR_MAC_OUI)
+        self.assertIn(myehdr.get_s_mac()[0:3], VENDOR_MAC_OUI)
         myehdrstr1 = str(myehdr)
         myehdr = EthernetFrame('10.0.0.1', '10.1.1.1', ETHERNET_HDR_GEN_RANDOM)
         myehdrstr2 = str(myehdr)


### PR DESCRIPTION
VENDOR_MAC_OUI shouldn't be modified while random octets are
generated. Instead, this change makes a clone of the list and modify it.

This pull request also makes related unit tests pass.
