### PR TITLE
Use early exit to simplify code

### DIFF
--- a/sniffles/rule_formats.py
+++ b/sniffles/rule_formats.py
@@ -33,53 +33,53 @@ class SnortRuleFormat(RuleFormat):
         self.sid = sid
 
     def toString(self):
-        my_snort_string = ""
-        if self.rule is not None:
-            myvals = str(self.rule).split(";")
-            mymap = {}
-            for v in myvals:
-                v = v.strip()
-                if len(v) > 0:
-                    v_list = v.split("=")
-                    mymap[v_list[0]] = v_list[1]
-            alert = "alert"
-            if "alert" in mymap:
-                alert = mymap["alert"]
-                del(mymap["alert"])
-            proto = "IP"
-            if "proto" in mymap:
-                proto = mymap["proto"]
-                del(mymap["proto"])
-            sip = "$HOME_NET"
-            if "sip" in mymap:
-                sip = mymap["sip"]
-                del(mymap["sip"])
-            sport = "any"
-            if "sport" in mymap:
-                sport = mymap["sport"]
-                del(mymap["sport"])
-            dir = "->"
-            if "dir" in mymap:
-                dir = mymap["dir"]
-                del(mymap["dir"])
-            dip = "$EXTERNAL_NET"
-            if "dip" in mymap:
-                dip = mymap["dip"]
-                del(mymap["dip"])
-            dport = "any"
-            if "dport" in mymap:
-                dport = mymap["dport"]
-                del(mymap["dport"])
-            myheader = "{} {} {} {} {} {} {} ".format(
-                alert, proto, sip, sport, dir, dip, dport)
-            myopt = "("
-            for o in mymap:
-                quote = ""
-                if o.lower().find("content") or o.lower().find("pcre"):
-                    quote = "\""
-                myopt += " " + o + ":" + quote + mymap[o] + quote + ";"
-            if "sid" not in mymap and self.sid is not None:
-                myopt += " sid:" + str(self.sid) + ";"
-            myopt += ")"
-            my_snort_string = myheader + myopt
-        return my_snort_string
+        if self.rule is None:
+            return ""
+
+        myvals = str(self.rule).split(";")
+        mymap = {}
+        for v in myvals:
+            v = v.strip()
+            if len(v) > 0:
+                v_list = v.split("=")
+                mymap[v_list[0]] = v_list[1]
+        alert = "alert"
+        if "alert" in mymap:
+            alert = mymap["alert"]
+            del(mymap["alert"])
+        proto = "IP"
+        if "proto" in mymap:
+            proto = mymap["proto"]
+            del(mymap["proto"])
+        sip = "$HOME_NET"
+        if "sip" in mymap:
+            sip = mymap["sip"]
+            del(mymap["sip"])
+        sport = "any"
+        if "sport" in mymap:
+            sport = mymap["sport"]
+            del(mymap["sport"])
+        dir = "->"
+        if "dir" in mymap:
+            dir = mymap["dir"]
+            del(mymap["dir"])
+        dip = "$EXTERNAL_NET"
+        if "dip" in mymap:
+            dip = mymap["dip"]
+            del(mymap["dip"])
+        dport = "any"
+        if "dport" in mymap:
+            dport = mymap["dport"]
+            del(mymap["dport"])
+        myheader = "{} {} {} {} {} {} {} ".format(
+            alert, proto, sip, sport, dir, dip, dport)
+        myopt = "("
+        for o in mymap:
+            quote = ""
+            if o.lower().find("content") or o.lower().find("pcre"):
+                quote = "\""
+            myopt += " " + o + ":" + quote + mymap[o] + quote + ";"
+        if "sid" not in mymap and self.sid is not None:
+            myopt += " sid:" + str(self.sid) + ";"
+        myopt += ")"
+        return myheader + myopt


### PR DESCRIPTION
Read the "Use Early Exits and continue to Simplify Code" section in the
LLVM Coding Standards for justification.