### PR TITLE
Delete a default parameter that causes an error

### DIFF
--- a/sniffles/feature.py
+++ b/sniffles/feature.py
@@ -24,7 +24,7 @@ class RangeNotation(AmbiguousNotation):
 
     # Range notation should be expressed as [x:y] where
     # x is lower bound and y is upper bound.
-    def __init__(self, notation=None):
+    def __init__(self, notation):
         self.notation = notation
         self.prefix = notation[0:1]
         self.suffix = notation[-1:]

--- a/sniffles/feature.py
+++ b/sniffles/feature.py
@@ -53,7 +53,7 @@ class ListNotation(AmbiguousNotation):
 
     # list notation should be [x,y] where x is lower bound and
     # y is upper bound.
-    def __init__(self, notation=None):
+    def __init__(self, notation):
         self.separator = notation
         self.prefix = notation[0:1]
         self.suffix = notation[-1:]


### PR DESCRIPTION
Havining `None` as `notation` causes an error because it is treated as a
list in the function.