### PR TITLE
Delete unnecessary default values

### DIFF
--- a/sniffles/sniffles.py
+++ b/sniffles/sniffles.py
@@ -267,7 +267,7 @@ def printRegEx(rules):
     return [0, 0, 0]
 
 
-def write_packets(queue=None, traffic_writer=None, time_lapse=1,
+def write_packets(queue, traffic_writer, time_lapse=1,
                   scan=False, scanners=None, slow_flows=None):
     """
         Packets are written out interleaved (round-robin) from


### PR DESCRIPTION
write_packets() must be called at least with a queue and a traffic
writer.