### PR TITLE
Add a unit test for the length of an IPv6 address

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -13,6 +13,7 @@ if __name__ == '__main__':
     from sniffles.test.test_traffic_splitter import *
     from sniffles.test.test_xml_rule_reader import *
     from sniffles.test.test_examples import *
+    from sniffles.test.test_feature import *
     from sniffles.test.test_pcrecomp import *
     from sniffles.test.test_nfa_build import *
     suites = [
@@ -22,6 +23,7 @@ if __name__ == '__main__':
         unittest.TestLoader().loadTestsFromTestCase(TestTrafficSplitter),
         unittest.TestLoader().loadTestsFromTestCase(TestXMLRuleReader),
         unittest.TestLoader().loadTestsFromTestCase(TestExamples),
+        unittest.TestLoader().loadTestsFromTestCase(TestFeature),
         unittest.TestLoader().loadTestsFromTestCase(TestPcreComp),
         unittest.TestLoader().loadTestsFromTestCase(TestNFABuild),
         unittest.TestLoader().loadTestsFromTestCase(TestOpAny),

--- a/sniffles/test/test_feature.py
+++ b/sniffles/test/test_feature.py
@@ -1,0 +1,9 @@
+from unittest import *
+from sniffles.feature import *
+
+
+class TestFeature(TestCase):
+
+    def test_ipv6(self):
+        ip = IPFeature("i1", 6, 100)
+        self.assertEqual(7, str(ip).count(':'))


### PR DESCRIPTION
This adds a unit test to reproduce the bug in [user story 98221704](https://www.pivotaltracker.com/story/show/98221704).