### PR TITLE
Add a unit test for get_dist_mac_oui

### DIFF
--- a/sniffles/test/test_rule_traffic_generator.py
+++ b/sniffles/test/test_rule_traffic_generator.py
@@ -20,27 +20,32 @@ class TestRuleTrafficGenerator(TestCase):
         self.assertNotEqual(myehdrstr1, str(myehdr))
 
     def test_build_ethernet_header_dist(self):
-        for i in range(0, 1000):
-            myehdr = EthernetFrame('10.2.2.2', '10.3.3.3',
-                                   ETHERNET_HDR_GEN_DISTRIBUTION,
-                                   'examples/mac_definition_file.txt')
-            self.assertEqual(''.join(['%02x' % i
-                                      for i in myehdr.get_d_mac()[0:2]]),
-                             '0080')
+        myehdr = EthernetFrame('10.2.2.2', '10.3.3.3',
+                               ETHERNET_HDR_GEN_DISTRIBUTION,
+                               'examples/mac_definition_file.txt')
+        self.assertEqual(''.join(['%02x' % i
+                                  for i in myehdr.get_d_mac()[0:2]]),
+                         '0080')
 
-            self.assertEqual(''.join(['%02x' % i
-                                      for i in myehdr.get_s_mac()[0:2]]),
-                             '0080')
-            mystr1 = str(myehdr)
-            myehdr = EthernetFrame('10.2.2.2', '10.3.3.3',
-                                   ETHERNET_HDR_GEN_DISTRIBUTION,
-                                   'examples/mac_definition_file.txt')
-            self.assertEqual(mystr1, str(myehdr))
-            myehdr.clear_globals()
-            myehdr = EthernetFrame('10.2.2.2', '10.3.3.3',
-                                   ETHERNET_HDR_GEN_DISTRIBUTION,
-                                   'examples/mac_definition_file.txt')
-            self.assertNotEqual(mystr1, str(myehdr))
+        self.assertEqual(''.join(['%02x' % i
+                                  for i in myehdr.get_s_mac()[0:2]]),
+                         '0080')
+        mystr1 = str(myehdr)
+        myehdr = EthernetFrame('10.2.2.2', '10.3.3.3',
+                               ETHERNET_HDR_GEN_DISTRIBUTION,
+                               'examples/mac_definition_file.txt')
+        self.assertEqual(mystr1, str(myehdr))
+        myehdr.clear_globals()
+        myehdr = EthernetFrame('10.2.2.2', '10.3.3.3',
+                               ETHERNET_HDR_GEN_DISTRIBUTION,
+                               'examples/mac_definition_file.txt')
+        self.assertNotEqual(mystr1, str(myehdr))
+
+    def test_get_dist_mac_oui_with_empty_dist(self):
+        ef = EthernetFrame('10.2.2.2', '10.3.3.3',
+                           ETHERNET_HDR_GEN_DISTRIBUTION)
+        with self.assertRaises(KeyError):
+            ef.get_dist_mac_oui()
 
     def test_build_ip_header(self):
         myipv4a = IPV4(None, None)


### PR DESCRIPTION
This tests the case when `prefix` is an empty list.