### PR TITLE
Fix icmp header creation.

### DIFF
--- a/sniffles/ruletrafficgenerator.py
+++ b/sniffles/ruletrafficgenerator.py
@@ -2398,19 +2398,23 @@ class TransportLayer(object):
 
 class ICMP(TransportLayer):
 
-    def __init__(self, type, code=None):
+    def __init__(self, type, code=None, roh=None):
         self.proto = "icmp"
         self.type = int(type)
         if code:
             self.code = int(code)
         else:
             self.code = 1
+        if roh:
+            self.rest_of_header = int(roh)
+        else:
+            self.rest_of_header = 0
         self.checksum = 0
-        self.size = 4
+        self.size = 8
 
     def get_transport_header(self):
-        icmp_bin = struct.pack('!BBH', self.type, self.code,
-                               self.checksum)
+        icmp_bin = struct.pack('!BBHI', self.type, self.code,
+                               self.checksum, self.rest_of_header)
         return icmp_bin
 
 

--- a/sniffles/test/test_rule_traffic_generator.py
+++ b/sniffles/test/test_rule_traffic_generator.py
@@ -212,11 +212,11 @@ class TestRuleTrafficGenerator(TestCase):
     def test_transport_header(self):
         mydata = struct.pack("!HH", 0, 0)
         mytrans = ICMP("1", "0")
-        mytesttrans = struct.pack("!BBH", 1, 0, 0)
+        mytesttrans = struct.pack("!BBHI", 1, 0, 0, 0)
         self.assertEqual(mytrans.get_transport_header(), mytesttrans)
         mytrans.set_checksum('10.0.0.1', '10.0.0.2', 1, mytrans.get_size() + 4,
                              mydata)
-        self.assertEqual(mytrans.get_checksum(), 0xeaf3)
+        self.assertEqual(mytrans.get_checksum(), 0xeaef)
 
         mytrans = TCP("4660", "128", 1, 0)
         mytesttrans = struct.pack("!HHIIHHHH", 0x1234, 0x80, 1, 0, 0x5000,
@@ -623,7 +623,7 @@ class TestRuleTrafficGenerator(TestCase):
             elif mypkt.get_proto() == 'udp':
                 self.assertEqual(mypkt.get_size(), 142)
             elif mypkt.get_proto() == 'icmp':
-                self.assertEqual(mypkt.get_size(), 138)
+                self.assertEqual(mypkt.get_size(), 142)
             mycount += 1
         self.assertEqual(mycount, 5)
 


### PR DESCRIPTION
Sniffles was creating ICMP packets with headers that were 4 bytes too small.  This fixes that problem.  However, it is still leaving the data empty so the ICMP headers are malformed for anything wanting to check those headers.  I will update that at a later date.