### PR TITLE
Minimum regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,6 +851,7 @@ Content Feature -- Inherits from Feature:
          m to the regex.
 - length: Defines the average length of the generated
           content.
+-  min_regex_length: Defines the minimum length of the regex.
 
 Protocol Feature -- Inherits from Feature:
 - proto_list: Defines the list of possible protocols,

--- a/sniffles/feature.py
+++ b/sniffles/feature.py
@@ -198,11 +198,13 @@ class Feature(object):
 
 
 class ContentFeature(Feature):
-    def __init__(self, name="content", regex=True, complexity_prob=0, len=0):
+    def __init__(self, name="content", regex=True, complexity_prob=0, len=0,
+                 min_regex_length=3):
         self.feature_name = name
         self.regex = regex
         self.complexity_prob = complexity_prob
         self.length = len
+        self.min_regex_length = min_regex_length
 
     def __str__(self):
         return self.toString()
@@ -222,12 +224,12 @@ class ContentFeature(Feature):
                                        [60, 30, 10],
                                        None, None,
                                        [20, 20, 40, 20],
-                                       50, 30)
+                                       50, 30, self.min_regex_length)
         else:
             mystring += generate_regex(self.length, 0,
                                        [100, 0, 0],
                                        [20, 35, 20, 20, 0],
-                                       None, None, 0, 0)
+                                       None, None, 0, 0, self.min_regex_length)
         if self.regex:
             mystring += "/"
             if complex:
@@ -461,6 +463,7 @@ class FeatureParser(object):
             len = 0
             proto_list = None
             version = 4
+            min_regex_length = 3
             if 'name' in mypairs:
                 name = mypairs['name']
             if 'lower_bound' in mypairs:
@@ -477,6 +480,10 @@ class FeatureParser(object):
                     regex = True
             if 'len' in mypairs:
                 len = int(mypairs['len'])
+            if 'min_regex_length' in mypairs:
+                min_regex_length = int(mypairs['min_regex_length'])
+                if min_regex_length < 1:
+                    min_regex_length = 1
             if 'proto_list' in mypairs:
                 plist = mypairs['proto_list']
                 plist = plist[1:-1]
@@ -492,7 +499,8 @@ class FeatureParser(object):
                 myfeature = Feature(name, lower_bound, upper_bound,
                                     complexity_prob, ambiguity_list)
             elif mypairs['type'].lower() == 'content':
-                myfeature = ContentFeature(name, regex, complexity_prob, len)
+                myfeature = ContentFeature(name, regex, complexity_prob, len,
+                                           min_regex_length)
             elif mypairs['type'].lower() == 'ip':
                 myfeature = IPFeature(name, version, complexity_prob)
             elif mypairs['type'].lower() == 'protocol':

--- a/sniffles/regex_generator.py
+++ b/sniffles/regex_generator.py
@@ -158,11 +158,13 @@ def generate_regex(lambd, max_len, type_dist, char_dist,
     max_len variable is larger than 0, then it is assumed that this is
     a recursive call and max_len is used as the length.  This function
     will continue concatenating structures to the regular expression
-    until the entire length has been generated.
+    until the entire length has been generated.  Note: the minimum
+    regex lenght is fixed at 3 characters (with possible decoration
+    i.e. repetition).
     """
     if lambd <= 0:
         lambd = 10
-    mylen = int(random.expovariate(1/lambd)) + 1
+    mylen = int(random.expovariate(1/lambd)) + 3
     if max_len > 0:
         mylen = max_len
     total_types = 3

--- a/sniffles/test/test_regex_generator.py
+++ b/sniffles/test/test_regex_generator.py
@@ -99,5 +99,8 @@ class TestRegexGenerator(TestCase):
 
     def test_min_regex(self):
         for i in range(0, 100):
-            myre = generate_regex(1, 10, None, None, None, None, 0, 0)
-            self.assertTrue(len(myre) > 3)
+            myre = generate_regex(1, 1, [100, 0, 0], [0, 0, 100, 0, 0], None, None, 0, 0, 1)
+            self.assertTrue(len(myre) == 1)
+            myre = generate_regex(1, 10, [100, 0, 0], [0, 0, 100, 0, 0], None, None, 0, 0, 2)
+            self.assertTrue(len(myre) >= 2)
+            self.assertTrue(len(myre) <= 10)

--- a/sniffles/test/test_regex_generator.py
+++ b/sniffles/test/test_regex_generator.py
@@ -96,3 +96,8 @@ class TestRegexGenerator(TestCase):
             lower = int(values[0])
             upper = int(values[1])
             self.assertTrue(lower <= upper)
+
+    def test_min_regex(self):
+        for i in range(0, 100):
+            myre = generate_regex(1, 10, None, None, None, None, 0, 0)
+            self.assertTrue(len(myre) > 3)


### PR DESCRIPTION
This sets the default minimum length to 3 chars for a regex and allows the minimum length to be adjusted.