### PR TITLE
Set the rule names for the rules parsed from a snort rule file

### DIFF
--- a/sniffles/regex_generator.py
+++ b/sniffles/regex_generator.py
@@ -139,7 +139,7 @@ def create_regex_list(number, lambd, type_dist, char_dist, class_dist,
                 myregex += o
         # check if this compiles or not
         if not check_pcre_compile(myregex):
-            print("pcre compile failed ... continuing")
+            # print("pcre compile failed ... continuing")
             continue
         myregex += "\n"
         myrelist.append(myregex)

--- a/sniffles/regex_generator.py
+++ b/sniffles/regex_generator.py
@@ -139,7 +139,7 @@ def create_regex_list(number, lambd, type_dist, char_dist, class_dist,
                 myregex += o
         # check if this compiles or not
         if not check_pcre_compile(myregex):
-            # print("pcre compile failed ... continuing")
+            # pcre compile failed. give another try until it passes
             continue
         myregex += "\n"
         myrelist.append(myregex)

--- a/sniffles/rulereader.py
+++ b/sniffles/rulereader.py
@@ -963,6 +963,7 @@ class SnortRuleParser(RuleParser):
     def __init__(self, filename=None):
         self.filename = None
         self.rules = []
+        self.rule_no = 0
 
     def parseHeader(self, line=None, ts=None):
         if line and ts:
@@ -1030,6 +1031,7 @@ class SnortRuleParser(RuleParser):
             self.parseHeader(rule, snort_ts)
             self.parseOptions(rule, snort_ts)
             snort_rule.addTS(snort_ts)
+            snort_rule.setRuleName("Snort-" + str(self.rule_no))
             self.addRule(snort_rule)
 
     def parseRuleFile(self, filename=None):
@@ -1039,6 +1041,7 @@ class SnortRuleParser(RuleParser):
             line = line.strip()
             if len(line) > 0 and line[0] != '#':
                 self.parseRule(line)
+                self.rule_no += 1
             line = self.fd.readline()
         self.fd.close()
 

--- a/sniffles/rulereader.py
+++ b/sniffles/rulereader.py
@@ -1089,6 +1089,8 @@ class PetabiRuleParser(RuleParser):
 
         for xmlrule in root.iter('rule'):
             myprule = Rule('Petabi')
+            if 'name' in xmlrule.attrib:
+                myprule.setRuleName(xmlrule.attrib['name'])
             for ts in xmlrule.iter('traffic_stream'):
 
                 mytsrule = None

--- a/sniffles/rulereader.py
+++ b/sniffles/rulereader.py
@@ -132,7 +132,6 @@ class RuleParser(object):
     def __init__(self, filename=None):
         self.rules = []
         self.filename = filename
-        self.rule_no = 0
 
     def addRule(self, rule=None):
         if rule:
@@ -158,7 +157,7 @@ class RuleParser(object):
         mypkt.addContent(mycon)
         ts.addPktRule(mypkt)
         basic_rule.addTS(ts)
-        basic_rule.setRuleName("Rule-" + str(self.rule_no))
+        basic_rule.setRuleName("Rule-" + str(len(self.rules)))
         self.addRule(basic_rule)
 
     def parseRuleFile(self, filename=None):
@@ -174,7 +173,6 @@ class RuleParser(object):
             line = line.strip()
             if len(line) > 0 and line[0] != '#':
                 self.parseRule(line)
-                self.rule_no += 1
             line = self.fd.readline()
         self.fd.close()
 
@@ -963,7 +961,6 @@ class SnortRuleParser(RuleParser):
     def __init__(self, filename=None):
         self.filename = None
         self.rules = []
-        self.rule_no = 0
 
     def parseHeader(self, line=None, ts=None):
         if line and ts:
@@ -1031,7 +1028,7 @@ class SnortRuleParser(RuleParser):
             self.parseHeader(rule, snort_ts)
             self.parseOptions(rule, snort_ts)
             snort_rule.addTS(snort_ts)
-            snort_rule.setRuleName("Snort-" + str(self.rule_no))
+            snort_rule.setRuleName("Snort-" + str(len(self.rules)))
             self.addRule(snort_rule)
 
     def parseRuleFile(self, filename=None):
@@ -1041,7 +1038,6 @@ class SnortRuleParser(RuleParser):
             line = line.strip()
             if len(line) > 0 and line[0] != '#':
                 self.parseRule(line)
-                self.rule_no += 1
             line = self.fd.readline()
         self.fd.close()
 

--- a/sniffles/snifflesconfig.py
+++ b/sniffles/snifflesconfig.py
@@ -775,6 +775,10 @@ class SnifflesConfig(object):
         print("-Z Reply Chance: chance that a scan will have a reply.")
         print("   In other words, chance the target port is open")
         print("   (default 20%).")
+        print("--resultfile result file: designate the name of the result file.")
+        print("   it conatains information about how packets are created"
+        print("   for example which rules are used for which packets.")
+        print("   by default, the file is named: result.txt.")
         print("")
         print("Please see README for examples and further details.")
 

--- a/sniffles/snifflesconfig.py
+++ b/sniffles/snifflesconfig.py
@@ -776,7 +776,7 @@ class SnifflesConfig(object):
         print("   In other words, chance the target port is open")
         print("   (default 20%).")
         print("--resultfile result file: designate the name of the result file.")
-        print("   it conatains information about how packets are created"
+        print("   it conatains information about how packets are created")
         print("   for example which rules are used for which packets.")
         print("   by default, the file is named: result.txt.")
         print("")


### PR DESCRIPTION
In addition to the changes in pcap-result pull request, the following items are addressed in this pull request.

- Set snort rule names for rules parsed from a snort rule file
- Show help for changing result file name that's created for describing pcap packet generation
- Suppress the warning message that's generated when a created regular expression fails to pass PCRE compile test