### PR TITLE
Make test_traffic_stream_split_too_large pass again

### DIFF
--- a/sniffles/ruletrafficgenerator.py
+++ b/sniffles/ruletrafficgenerator.py
@@ -698,7 +698,7 @@ class TrafficStream(object):
             # Nothing left.
         # Increment time stamp for next packet
         self.incrementTime(int(round(random.expovariate(1/self.latency)))+1)
-        if self.rule:
+        if pkt is not None and self.rule:
             pkt.set_ts_rule(self.rule)
         return pkt
 


### PR DESCRIPTION
This fixes the following unit test failure:
```
======================================================================
ERROR: test_traffic_stream_split_too_large (sniffles.test.test_rule_traffic_generator.TestRuleTrafficGenerator)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/Data/Development/sniffles/build/lib.macosx-10.12-x86_64-3.6/sniffles/test/test_rule_traffic_generator.py", line 863, in test_traffic_stream_split_too_large
    mypkt = myts.getNextPacket()
  File "/Volumes/Data/Development/sniffles/build/lib.macosx-10.12-x86_64-3.6/sniffles/ruletrafficgenerator.py", line 702, in getNextPacket
    pkt.set_ts_rule(self.rule)
AttributeError: 'NoneType' object has no attribute 'set_ts_rule'

----------------------------------------------------------------------
```