### PR TITLE
Modified Sniffles to create background traffic with the args of option B given protocol distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,15 @@ Command Line Options:
   - -b Bidirectional data: Data will be generated in both directions
      of a TCP stream. ACKs will be turned on.  This feature is off
      by default.
+
   - -B Background Traffic Percentage: Set this value between 1 and
      100 to produce Background Traffic. This traffic will consist of
      even selections of following generic application protocols:
      FTP, HTTP, IMAP, POP and SMTP. By default it is set to 0.
+
+  - -B [Background Traffic Protocol:Percentage]: Set at least one
+     protocol with value between 1 and 100 to generate each Background
+     Traffic. For example: "http:20,ftp:30,smtp:10".
 
   - -c Count: Number of streams to create.  Each stream will contain a
      minimum of 1 packet.  Packet will be between two end-points as

--- a/README.md
+++ b/README.md
@@ -126,14 +126,15 @@ Command Line Options:
      of a TCP stream. ACKs will be turned on.  This feature is off
      by default.
 
-  - -B Background Traffic Percentage: Set this value between 1 and
-     100 to produce Background Traffic. This traffic will consist of
-     even selections of following generic application protocols:
-     FTP, HTTP, IMAP, POP and SMTP. By default it is set to 0.
-
   - -B [Background Traffic Protocol:Percentage]: Set at least one
-     protocol with value between 1 and 100 to generate each Background
-     Traffic. For example: "http:20,ftp:30,smtp:10".
+     protocol with value between 1 and 100 to produce Background
+     Traffic. This value represents the percentage of the total
+     amount of traffic.
+     Protocols available: FTP, HTTP, IMAP, POP and SMTP.
+     For example: "http:20,ftp:30,smtp:10".
+     Enter only one number as the argument value to generate randomly
+     traffic.
+     For example: "80".
 
   - -c Count: Number of streams to create.  Each stream will contain a
      minimum of 1 packet.  Packet will be between two end-points as

--- a/sniffles/sniffles.py
+++ b/sniffles/sniffles.py
@@ -85,6 +85,7 @@ def start_generation(sconf):
     global TOTAL_GENERATED_STREAMS
     global TOTAL_GENERATED_PACKETS
     global FINAL
+
     myrulelist = RuleList()
     if sconf.getRuleFile() and sconf.getRuleDir():
         print("You must specify either a single rule file, "
@@ -105,8 +106,22 @@ def start_generation(sconf):
     allrules = myrulelist.getParsedRules()
     # Retrieve Background Traffic percentage
     back_traffic_percent = sconf.getBackgroundTraffic()
-    back_dist_list = None
-    back_absent_proto = None
+    if sconf.getBackgroundTrafficRule() is not None:
+        bt_rule = BackgroundTrafficRule()
+        background_traffic_rule = sconf.getBackgroundTrafficRule()
+        for i in range(0, int(len(background_traffic_rule)/2)):
+            bt_rule.setDistribution(background_traffic_rule[2*i], int(background_traffic_rule[2*i+1]))
+        bt_rule.updateProbability()
+        back_dist_list = bt_rule.getProbabilityDist()
+        # Leave only the protocol specified in the list.
+        # Becuase the sum of each percent is Background Traffic percentage.
+        while 'remainder' in back_dist_list:
+            back_dist_list.remove('remainder')
+        back_absent_proto = None
+    else :
+        back_dist_list = None
+        back_absent_proto = None
+
     # Get Background Traffic Rule if given
     if myrulelist.getBackgroundTraffic():
         bt_rule = myrulelist.getBackgroundTraffic()
@@ -191,6 +206,8 @@ def start_generation(sconf):
                 # Update the content with saved information
                 bt_rule = BackgroundTrafficRule()
                 bt_rule.updateContent(None, back_dist_list, back_absent_proto)
+                # Add the application protocol to the rule name
+                btrule.setRuleName("Background Traffic-" + bt_rule.getProtocolType())
                 btrule.addTS(bt_rule)
                 conversation = Conversation(btrule, sconf, current_sec,
                                             current_usec + flow_start_offset)

--- a/sniffles/sniffles.py
+++ b/sniffles/sniffles.py
@@ -107,14 +107,9 @@ def start_generation(sconf):
     # Retrieve Background Traffic percentage
     back_traffic_percent = sconf.getBackgroundTraffic()
     if sconf.getBackgroundTrafficRule() is not None:
-        bt_rule = BackgroundTrafficRule()
-        background_traffic_rule = sconf.getBackgroundTrafficRule()
-        for i in range(0, int(len(background_traffic_rule)/2)):
-            bt_rule.setDistribution(background_traffic_rule[2*i], int(background_traffic_rule[2*i+1]))
-        bt_rule.updateProbability()
+        bt_rule = sconf.getBackgroundTrafficRule()
         back_dist_list = bt_rule.getProbabilityDist()
-        # Leave only the protocol specified in the list.
-        # Becuase the sum of each percent is Background Traffic percentage.
+        # Leave only the protocol specified in the list to affects the overall amount of traffic.
         while 'remainder' in back_dist_list:
             back_dist_list.remove('remainder')
         back_absent_proto = None

--- a/sniffles/snifflesconfig.py
+++ b/sniffles/snifflesconfig.py
@@ -41,7 +41,7 @@ class SnifflesConfig(object):
     def __init__(self, cmd=None):
         self.bi = False
         self.background_traffic = 0
-        self.background_traffic_rule = []
+        self.background_traffic_rule = None
         self.concurrent_flows = 1000
         self.config_file = None
         self.mix_mode = False
@@ -471,15 +471,15 @@ class SnifflesConfig(object):
                 self.background_traffic = int(args[0])
             else:
                args = re.split('[,]+', arg)
+               self.background_traffic_rule = BackgroundTrafficRule();
                for i in range(0, len(args)):
                    args_dist = re.split('[:]+', args[i])
-                   if len(args_dist) == 1:
+                   if len(args_dist) == 1 or args_dist[1] is None:
                        self.usage()
                    else:
                        self.background_traffic += int(args_dist[1])
-                       self.background_traffic_rule.append(args_dist[0])
-                       self.background_traffic_rule.append(args_dist[1])
-
+                       self.background_traffic_rule.setDistribution(args_dist[0], int(args_dist[1]))
+               self.background_traffic_rule.updateProbability()
             if self.background_traffic < 0 or self.background_traffic > 100:
                 print("Must set percentage between 0 and 100")
                 self.usage()
@@ -681,15 +681,15 @@ class SnifflesConfig(object):
         print("   sent.  Off by default.")
         print("-b Bi-directional data: Send data in both directions.")
         print("   Off by default.  Automatically sets TCP acks.")
-        print("-B Background Traffic Percentage: Set this value between 1 and")
-        print("   100 to produce Background Traffic. This traffic will")
-        print("   consist of even selections of following generic application")
-        print("   protocols: FTP, HTTP, IMAP, POP and SMTP. By default, ")
-        print("   it is set to 0.")
         print("-B [Background Traffic Protocol:Percentage]: Set at least one")
-        print("   protocol with value between 1 and 100 to generate each")
-        print("   Background Traffic.")
+        print("   protocol with value between 1 and 100 to produce Background")
+        print("   Traffic. This value represents the percentage of the total")
+        print("   amount of traffic.")
+        print("   Protocols available: FTP, HTTP, IMAP, POP and SMTP.")
         print("   For example: \"http:20,ftp:30,smtp:10\".")
+        print("   Enter only one number as the argument value to generate randomly")
+        print("   traffic .")
+        print("   For example: \"80\".")
         print("-c Count: Number of streams to create.  Each stream will")
         print("   contain a minimum of 1 packet.  Packet will be between")
         print("   two end-points as defined by the rule or randomly chosen.")

--- a/sniffles/snifflesconfig.py
+++ b/sniffles/snifflesconfig.py
@@ -41,6 +41,7 @@ class SnifflesConfig(object):
     def __init__(self, cmd=None):
         self.bi = False
         self.background_traffic = 0
+        self.background_traffic_rule = []
         self.concurrent_flows = 1000
         self.config_file = None
         self.mix_mode = False
@@ -390,6 +391,12 @@ class SnifflesConfig(object):
     def getWriteRegEx(self):
         return self.write_reg_ex
 
+    def getBackgroundTrafficRule(self):
+        return self.background_traffic_rule
+
+    def setBackgroundTrafficRule(self, value):
+        self.background_traffic_rule = value
+
     def setWriteRegExe(self, value):
         self.write_reg_ex = value
 
@@ -459,7 +466,20 @@ class SnifflesConfig(object):
             self.tcp_ack = True
         # Set percentage of background traffics to be added
         elif opt == "-B":
-            self.background_traffic = int(arg)
+            args = re.split('[:]+', arg)
+            if len(args) == 1:
+                self.background_traffic = int(args[0])
+            else:
+               args = re.split('[,]+', arg)
+               for i in range(0, len(args)):
+                   args_dist = re.split('[:]+', args[i])
+                   if len(args_dist) == 1:
+                       self.usage()
+                   else:
+                       self.background_traffic += int(args_dist[1])
+                       self.background_traffic_rule.append(args_dist[0])
+                       self.background_traffic_rule.append(args_dist[1])
+
             if self.background_traffic < 0 or self.background_traffic > 100:
                 print("Must set percentage between 0 and 100")
                 self.usage()
@@ -647,8 +667,9 @@ class SnifflesConfig(object):
 
     def usage(self):
         print("Sniffles--Traffic Generator for testing IDS")
-        print("usage: ./sniffles [-d dir | -f file] [-B percentage] [-c count]")
+        print("usage: ./sniffles [-d dir | -f file]  [-c count]")
         print(" [-C # concurrent flows] [-D traffic duration] [-F config]")
+        print(" [-B percentage | protocol:percentage,protocol:percentage,..]")
         print(" [-h \"comma-sep list\"] [-H \"comma-sep list\"]")
         print(" [-i ipv6 chance] [-I scan intensity]")
         print(" [-l pkt_length] [-L time lapse] [-M mac_addr_def file]")
@@ -665,6 +686,10 @@ class SnifflesConfig(object):
         print("   consist of even selections of following generic application")
         print("   protocols: FTP, HTTP, IMAP, POP and SMTP. By default, ")
         print("   it is set to 0.")
+        print("-B [Background Traffic Protocol:Percentage]: Set at least one")
+        print("   protocol with value between 1 and 100 to generate each")
+        print("   Background Traffic.")
+        print("   For example: \"http:20,ftp:30,smtp:10\".")
         print("-c Count: Number of streams to create.  Each stream will")
         print("   contain a minimum of 1 packet.  Packet will be between")
         print("   two end-points as defined by the rule or randomly chosen.")


### PR DESCRIPTION
Apply the correction according to the modification request

- embed a backgroundtrafficrule in snifflesconfig.
- got rid of the getters (198-210) and removed the initializers (44-49).
- specified how to use it and updated the documentation to show the new usage.