### PR TITLE
Delete unnecessary usage of codecs

### DIFF
--- a/sniffles/feature.py
+++ b/sniffles/feature.py
@@ -1,4 +1,3 @@
-import codecs
 import random
 import sys
 
@@ -407,7 +406,7 @@ class FeatureParser(object):
     def parseFile(self, filename=None):
         if filename is not None:
             try:
-                fd = codecs.open(filename, 'r', encoding='utf-8')
+                fd = open(filename, encoding='utf-8')
             except Exception as err:
                 print("Could not read feature file.")
                 print("FeatureParser-parseFile: " + str(err))

--- a/sniffles/petabi_rule_writer/petabi_rule_writer.py
+++ b/sniffles/petabi_rule_writer/petabi_rule_writer.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 import re
 import random
-import codecs
 from collections import OrderedDict
 import sniffles.pcrecomp
 from sniffles.nfa import PCRE_OPT
@@ -150,7 +149,7 @@ def regexParser(filename=None):
     regex = []
     if filename:
         try:
-            fd = codecs.open(filename, 'r', encoding='utf-8')
+            fd = open(filename, encoding='utf-8')
         except Exception as err:
             print("Could not read regex file")
             print("regexParser: " + str(err))
@@ -362,7 +361,7 @@ def formatPktRule(regex=None, count='1', fragment=False,
 # Output: petabi rule file.
 def printRule(ruleList=None, outfile=None):
     if ruleList:
-        fd = codecs.open(outfile, 'w', encoding='utf-8')
+        fd = open(outfile, 'w', encoding='utf-8')
         fd.write("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
         fd.write("<petabi_rules>\n")
         for key in ruleList:

--- a/sniffles/rand_rule_gen.py
+++ b/sniffles/rand_rule_gen.py
@@ -1,5 +1,4 @@
 import argparse
-import codecs
 
 from sniffles.feature import *
 from sniffles.rule_formats import *
@@ -34,7 +33,7 @@ def generateRules(feature_list, count=1):
 
 def printRules(rule_list=None, outfile=None, rule_format=None):
     if rule_list and outfile:
-        fd = codecs.open(outfile, 'w', encoding='utf-8')
+        fd = open(outfile, 'w', encoding='utf-8')
         for rule in rule_list:
             rwf = getRuleWithFormat(rule, rule_format)
             fd.write(str(rwf))

--- a/sniffles/rulereader.py
+++ b/sniffles/rulereader.py
@@ -1,4 +1,3 @@
-import codecs
 import random
 import re
 import sys
@@ -167,7 +166,7 @@ class RuleParser(object):
 
     def parseRuleFile(self, filename=None):
         try:
-            self.fd = codecs.open(filename, 'r', encoding='utf-8')
+            self.fd = open(filename, encoding='utf-8')
         except Exception as err:
             print("Error reading Basic rule file: Could not open: ",
                   filename)
@@ -1284,7 +1283,7 @@ class SnortRuleParser(RuleParser):
 
     def openSnortFile(self, filename):
         try:
-            self.fd = codecs.open(filename, 'r', encoding='utf-8')
+            self.fd = open(filename, encoding='utf-8')
         except Exception as err:
             print("Error reading Snort rule file: Could not open: ",
                   filename)


### PR DESCRIPTION
Since `open()` takes the `encoding` argument, there is no need to use `codecs`.