### PR TITLE
Fix pkt p strm

### DIFF
--- a/sniffles/ruletrafficgenerator.py
+++ b/sniffles/ruletrafficgenerator.py
@@ -310,7 +310,8 @@ class TrafficStream:
                 self.flow_ack = True
             flow_opts = rule.getFlowOptions()
             self.myp = rule.getPkts()
-            self.packets_in_stream = len(rule.getPkts())
+            if len(rule.getPkts()) > self.packets_in_stream:
+                self.packets_in_stream = len(rule.getPkts())
             self.proto = rule.getProto()
             self.dport = Port(rule.getDport())
             self.sport = Port(rule.getSport())
@@ -541,6 +542,7 @@ class TrafficStream:
                            seq=None, ack=None):
         if myrule is None:
             myrule = self.rule
+
         pkt = None
         con = None
         if self.full_eval:
@@ -637,7 +639,8 @@ class TrafficStream:
             # If p_count is zero, then we have finished with this pkt rule.
             if self.p_count <= 0:
                 self.packets_in_stream -= 1
-                if len(self.myp) > 0:
+                if len(self.myp) > 1 or len(self.myp) == 1 and \
+                   self.packets_in_stream == 0 :
                     self.myp.pop(0)
                 if self.content_string is not None:
                     self.content_string = None

--- a/sniffles/ruletrafficgenerator.py
+++ b/sniffles/ruletrafficgenerator.py
@@ -640,7 +640,7 @@ class TrafficStream:
             if self.p_count <= 0:
                 self.packets_in_stream -= 1
                 if len(self.myp) > 1 or len(self.myp) == 1 and \
-                   self.packets_in_stream == 0 :
+                   self.packets_in_stream == 0:
                     self.myp.pop(0)
                 if self.content_string is not None:
                     self.content_string = None

--- a/sniffles/test/test_rule_traffic_generator.py
+++ b/sniffles/test/test_rule_traffic_generator.py
@@ -914,8 +914,27 @@ class TestRuleTrafficGenerator(unittest.TestCase):
         self.assertFalse(myts[0].testTypeRule('ScanAttack'))
         mycon = Conversation(myrule, sconf)
         self.assertEqual(1, mycon.getNumberOfStreams())
-        print(str(mycon))
         count = 0
         while mycon.getNextPacket():
             count += 1
         self.assertEqual(7, count)
+
+    def test_snort_rule_w_pkt_p_stream_set_w_ack(self):
+        myparser = SnortRuleParser()
+        myparser.parseRule(r'alert tcp $EXTERNAL_NET any -> '
+                           r'$HOME_NET $HTTP_PORTS (msg:"test1-1";'
+                           r' flow:to_server,established; content:'
+                           r'"work.Method.denyExecution"; nocase; '
+                           r'http_uri; content:"u0023"; nocase; http_uri;'
+                           r' sid:1;')
+        sconf = SnifflesConfig()
+        sconf.setPktsPerStream(7)
+        sconf.setTCPACK(True)
+        self.assertEqual(7, sconf.getPktsPerStream())
+        myrule = myparser.getRules()[0]
+        mycon = Conversation(myrule, sconf)
+        self.assertEqual(1, mycon.getNumberOfStreams())
+        count = 0
+        while mycon.getNextPacket():
+            count += 1
+        self.assertEqual(14, count)


### PR DESCRIPTION
Fixes an error where traffic streams built from a rule from a rule file would not allow generating more packets for that stream than the number of pkt rules.  Have changed this so that if the packets per stream is set the last packet rule will be used for all remaining requests.