### PR TITLE
Use tox to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-script:
-  - python setup.py test
+install: pip install tox-travis
+script:  tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist =
+    py36
+
+[testenv]
+deps =
+    sortedcontainers
+    pytest
+commands =
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py36
+    {py34,py35,py36}
 
 [testenv]
 deps =


### PR DESCRIPTION
tox allows running unit tests with different Python versions (if they are installed on the system). For example, to test with Python 3.6, run `tox -e py36`.